### PR TITLE
補強課表 API

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -41,7 +41,7 @@ class Course < ApplicationRecord
 
   # 重載 json serializer，改寫 time_slots
   # @todo: 用 fast_jsonapi?
-  def as_json(options = {})
+  def serializable_hash(options = {})
     super({ **options, except: :time_slots }).tap do |result|
       result[:time_slots] = convert_time_slots
     end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -12,28 +12,35 @@ class Course < ApplicationRecord
 
   enum time_slot_code: %I[M N A B C D X E F G H Y I J k L]
 
-  # Currently in DB we use 12bytes(96bit) to preserve course time slots
-  # (16 slots * 6 days per week = 96bit),
-  # thus we need to convert it to human readable form,
-  # before passing data to frontend.
-  # TODO: should we do this at frontend?
+  # 現在 DB 裡用 12bytes(96bit) 的 binary 來保存課程時段
+  # (16 的時段 * 每週 6 天 = 96(bit)),
+  # 所以在傳給前端時我們需要轉換成比較容易讀得懂的形式
   def convert_time_slots
+    # 96bits
+    # 切成 6 個 2bytes 的 string
+    # 將每個 2bytes string 轉成長度 16 的 bitmask: [0, 1, 1 ...., 0]
+    # 將每個 bitmask 轉成時段對應的英文字母陣列: ['A', 'B', 'M']
+    # 將字母陣列跟 index 結合: [0, ['A, 'B', 'M']]
+    # 將前面作成的 array 轉成 hash
     time_slots
       .chars.each_slice(2)
       .map { |data| data.join('').unpack1('S') }
-      .map.with_index do |data, index|
+      .map do |data|
         16.times
           .select { |i| (data & (1 << i)).positive? }
           .map { |i| self.class.time_slot_codes.key(i) }
-          .reduce((index + 1).to_s, :+)
       end
-      .select { |r| r.length > 1 }
-      .join
+      .map.with_index { |data, index| [index, data] }
+      .each_with_object({}) do |entry, result|
+        key = entry[0] + 1
+        value = entry[1]
+        result[key] = value unless value.empty?
+        result
+      end
   end
 
-  # override json serializer, add converted time slots
-  # TODO: should we use fast_jsonapi?
-  # TODO: should we include raw data?
+  # 重載 json serializer，改寫 time_slots
+  # @todo: 用 fast_jsonapi?
   def as_json(options = {})
     super({ **options, except: :time_slots }).tap do |result|
       result[:time_slots] = convert_time_slots


### PR DESCRIPTION
改寫課表格式
原本: 字串型態，`"1A2BC"`
改成: json格式， `{ "1" : ["A"], "2":["B", "C"] }`
- 改寫 convert_time_slots 方法，註解改用中文寫 ca2fd99
- as_json => serializable_hash，因 serializable_hash 才能做 nested association json serialization 
815a76d
