### PR TITLE
Add exception handler if record not found

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,11 +1,16 @@
 class ApplicationController < ActionController::API
   include DeviseTokenAuth::Concerns::SetUserByToken
   before_action :configure_permitted_parameters, if: :devise_controller?
+  rescue_from ActiveRecord::RecordNotFound, with: :render_404
 
   protected
 
   # define /auth sign up API permited parameters
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :email, :password, :admission_year])
+  end
+
+  def render_404
+    render status: :not_found
   end
 end


### PR DESCRIPTION
* 加入 `ActiveRecord::RecordNotFound` exception相對應的handler
* 此handler `render_404` 會直接回傳 `404 not_found` 的response