### PR TITLE
修正二手書API

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -66,8 +66,8 @@ class BooksController < ApplicationController
   def book_params
     params.fetch(:book, {})
           .permit(
-            :time, :name, :authors, :info, :cover_image,
-            :preview_url, :price, :status
+            :name, :isbn, :authors, :info, :contact_way, :cover_image,
+            :price
           )
   end
 end

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -1,5 +1,6 @@
 class BooksController < ApplicationController
   before_action :set_book, only: [:show, :update, :destroy]
+  before_action :authenticate_user!, except: [:index, :show]
 
   # GET /books
   def index
@@ -36,7 +37,9 @@ class BooksController < ApplicationController
 
   # PATCH/PUT /books/1
   def update
-    if @book.update(book_params)
+    if current_user.id != @book.user_id
+      render json: { "error": "user doesn't match" }, status: :unauthorized
+    elsif @book.update(book_params)
       render json: @book
     else
       render json: @book.errors, status: :unprocessable_entity
@@ -45,7 +48,11 @@ class BooksController < ApplicationController
 
   # DELETE /books/1
   def destroy
-    @book.destroy
+    if current_user.id != @book.user_id
+      render json: { "error": "user doesn't match" }, status: :unauthorized
+    else
+      @book.destroy
+    end
   end
 
   private

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -25,7 +25,7 @@ class BooksController < ApplicationController
 
   # POST /books
   def create
-    @book = Book.new(book_params)
+    @book = current_user.books.build(book_params)
 
     if @book.save
       render json: @book, status: :created, location: @book

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -1,6 +1,7 @@
 class BooksController < ApplicationController
-  before_action :set_book, only: [:show, :update, :destroy]
+  before_action :set_book, only: [:show, :update, :destroy, :status]
   before_action :authenticate_user!, except: [:index, :show]
+  wrap_parameters Book, format: :json, exclude: []
 
   # GET /books
   def index
@@ -27,7 +28,7 @@ class BooksController < ApplicationController
   # POST /books
   def create
     @book = current_user.books.build(book_params)
-
+    @book.add_applicable_courses(course_id_array)
     if @book.save
       render json: @book, status: :created, location: @book
     else
@@ -39,8 +40,19 @@ class BooksController < ApplicationController
   def update
     if current_user.id != @book.user_id
       render json: { "error": "user doesn't match" }, status: :unauthorized
-    elsif @book.update(book_params)
+    elsif @book.update_book(book_params, course_id_array)
       render json: @book
+    else
+      render json: @book.errors, status: :unprocessable_entity
+    end
+  end
+
+  # PATCH/PUT /books/1/status
+  def status
+    if current_user.id != @book.user_id
+      render json: { "error": "user doesn't match" }, status: :unauthorized
+    elsif @book.update_attributes(status: params[:status])
+      render json: { id: @book.id, status: @book.status }, status: :ok
     else
       render json: @book.errors, status: :unprocessable_entity
     end
@@ -59,7 +71,7 @@ class BooksController < ApplicationController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_book
-    @book = Book.includes(:courses, :user).find(params[:id])
+    @book = Book.includes(:courses, :user).find(params[:id] || params[:book_id])
   end
 
   # Only allow a trusted parameter "white list" through.
@@ -69,5 +81,20 @@ class BooksController < ApplicationController
             :name, :isbn, :authors, :info, :contact_way, :cover_image,
             :price
           )
+  end
+
+  # Get and sort all the course_id within parameters
+  def course_id_array
+    if params.fetch(:book, {}).key?(:courses)
+      params.fetch(:book, {})
+            .permit(
+              courses: [:course_id]
+            )
+            .fetch(:courses)
+            .map { |course| course[:course_id] }
+            .try(:sort_by!) { |id| id }
+    else
+      []
+    end
   end
 end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -4,6 +4,7 @@ class Book < ApplicationRecord
   belongs_to :user
   has_many :books_courses
   has_many :courses, through: :books_courses
+  accepts_nested_attributes_for :books_courses, allow_destroy: true
 
   validates_numericality_of :price, only_integer: true
 
@@ -18,5 +19,42 @@ class Book < ApplicationRecord
         end
       end
     end
+  end
+
+  def add_applicable_courses(course_id_array)
+    courses << Course.includes(:teachers, :permanent_course)
+                     .find(course_id_array)
+  end
+
+  def update_book(book_params, course_id_array)
+    index = 0
+    books_courses_ = books_courses.order(:course_id)
+    books_courses_id_delete_array = []
+    new_books_courses_id_array = []
+    course_id_array.each do |course_id|
+      comparison_result = 1
+      until books_courses_[index].nil?
+        comparison_result = course_id <=> books_courses_[index][:course_id]
+        case comparison_result
+        when 1
+          books_courses_id_delete_array << books_courses_[index][:id]
+          index += 1
+        when 0
+          index += 1
+          break
+        when -1
+          new_books_courses_id_array << course_id
+          break
+        end
+      end
+      new_books_courses_id_array << course_id if comparison_result == 1
+    end
+    books_courses_[index..-1].try(:each) do |books_course|
+      books_courses_id_delete_array << books_course[:id]
+    end
+    books_courses.where(id: books_courses_id_delete_array).delete_all
+    courses << Course.find(new_books_courses_id_array)
+    courses.reload
+    update(book_params)
   end
 end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -11,8 +11,12 @@ class Book < ApplicationRecord
     options = options.try(:dup) || {}
 
     super({ **options, except: :user_id }).tap do |result|
-      result[:user] = user
-      result[:courses] = courses
+      result[:user] = user.serializable_hash(only: [:id, :name])
+      result[:courses] = [].tap do |i|
+        courses.each do |course|
+          i << course.serializable_hash_for_books
+        end
+      end
     end
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -54,4 +54,16 @@ class Course < ApplicationRecord
       result[:ratings] = ratings
     end
   end
+
+  def serializable_hash_for_books
+    {}.tap do |result|
+      result[:course_id] = id
+      result[:course_name] = permanent_course.name
+      result[:teachers] = [].tap do |i|
+        teachers.each do |teacher|
+          i << teacher.serializable_hash_for_books
+        end
+      end
+    end
+  end
 end

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -7,4 +7,11 @@ class Teacher < ApplicationRecord
   self.primary_key = :id
   has_many :teachers_courses
   has_many :courses, through: :teachers_courses
+
+  def serializable_hash_for_books
+    {}.tap do |result|
+      result[:id] = id
+      result[:name] = name
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,9 @@ Rails.application.routes.draw do
       resources :teachers, only: [:index]
       resources :semesters, only: [:index]
       resources :bulletins
-      resources :books
+      resources :books do
+        patch 'status', to: 'books#status', as: :status
+      end
       resources :past_exams
       resources :events do
         post 'follow', to: 'events#follow', as: :follow

--- a/db/migrate/20181017051742_add_contact_way_to_books.rb
+++ b/db/migrate/20181017051742_add_contact_way_to_books.rb
@@ -1,0 +1,5 @@
+class AddContactWayToBooks < ActiveRecord::Migration[5.2]
+  def change
+    add_column :books, :contact_way, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_05_030558) do
+ActiveRecord::Schema.define(version: 2018_10_17_051742) do
 
-  create_table "books", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "books", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.string "isbn"
     t.string "authors"
@@ -25,10 +25,11 @@ ActiveRecord::Schema.define(version: 2018_09_05_030558) do
     t.integer "view_count", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "contact_way"
     t.index ["user_id"], name: "index_books_on_user_id"
   end
 
-  create_table "books_courses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "books_courses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "book_id"
     t.bigint "course_id"
     t.datetime "created_at", null: false
@@ -37,7 +38,7 @@ ActiveRecord::Schema.define(version: 2018_09_05_030558) do
     t.index ["course_id"], name: "index_books_courses_on_course_id"
   end
 
-  create_table "bulletins", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "bulletins", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "title", default: "untitled", null: false
@@ -49,14 +50,14 @@ ActiveRecord::Schema.define(version: 2018_09_05_030558) do
     t.index ["author_id"], name: "index_bulletins_on_author_id"
   end
 
-  create_table "colleges", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "colleges", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.string "code", limit: 1, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "course_ratings", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "course_ratings", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "course_id"
     t.integer "category"
     t.integer "score"
@@ -65,7 +66,7 @@ ActiveRecord::Schema.define(version: 2018_09_05_030558) do
     t.index ["course_id"], name: "index_course_ratings_on_course_id"
   end
 
-  create_table "courses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "courses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "code"
     t.string "remarks"
     t.integer "credit"
@@ -89,7 +90,7 @@ ActiveRecord::Schema.define(version: 2018_09_05_030558) do
     t.index ["semester_id"], name: "index_courses_on_semester_id"
   end
 
-  create_table "departments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "departments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.integer "category", default: 0, null: false
     t.string "department_type", limit: 1
@@ -100,7 +101,7 @@ ActiveRecord::Schema.define(version: 2018_09_05_030558) do
     t.index ["college_id"], name: "index_departments_on_college_id"
   end
 
-  create_table "events", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "events", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "event_type"
     t.string "title", default: "untitled", null: false
     t.string "organization"
@@ -118,7 +119,7 @@ ActiveRecord::Schema.define(version: 2018_09_05_030558) do
     t.index ["user_id"], name: "index_events_on_user_id"
   end
 
-  create_table "past_exams", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "past_exams", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "description"
     t.integer "download_count", default: 0
     t.string "file"
@@ -130,7 +131,7 @@ ActiveRecord::Schema.define(version: 2018_09_05_030558) do
     t.index ["uploader_id"], name: "index_past_exams_on_uploader_id"
   end
 
-  create_table "permanent_courses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "permanent_courses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.string "code"
     t.string "description"
@@ -138,20 +139,21 @@ ActiveRecord::Schema.define(version: 2018_09_05_030558) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "semesters", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "semesters", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "year"
     t.integer "term"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "teachers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "teachers", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "id"
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "teachers_courses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "teachers_courses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "teacher_id"
     t.bigint "course_id"
     t.datetime "created_at", null: false
@@ -160,7 +162,7 @@ ActiveRecord::Schema.define(version: 2018_09_05_030558) do
     t.index ["teacher_id"], name: "index_teachers_courses_on_teacher_id"
   end
 
-  create_table "timetables", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "timetables", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id"
     t.boolean "shareable", default: false
     t.datetime "created_at", null: false
@@ -168,7 +170,7 @@ ActiveRecord::Schema.define(version: 2018_09_05_030558) do
     t.index ["user_id"], name: "index_timetables_on_user_id"
   end
 
-  create_table "timetables_courses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "timetables_courses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "timetable_id"
     t.bigint "course_id"
     t.datetime "created_at", null: false
@@ -177,7 +179,7 @@ ActiveRecord::Schema.define(version: 2018_09_05_030558) do
     t.index ["timetable_id"], name: "index_timetables_courses_on_timetable_id"
   end
 
-  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "provider", default: "email", null: false
     t.string "uid", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -208,7 +210,7 @@ ActiveRecord::Schema.define(version: 2018_09_05_030558) do
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
-  create_table "users_course_ratings", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "users_course_ratings", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id"
     t.bigint "course_rating_id"
     t.datetime "created_at", null: false
@@ -217,7 +219,7 @@ ActiveRecord::Schema.define(version: 2018_09_05_030558) do
     t.index ["user_id"], name: "index_users_course_ratings_on_user_id"
   end
 
-  create_table "users_courses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "users_courses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id"
     t.bigint "course_id"
     t.datetime "created_at", null: false
@@ -226,7 +228,7 @@ ActiveRecord::Schema.define(version: 2018_09_05_030558) do
     t.index ["user_id"], name: "index_users_courses_on_user_id"
   end
 
-  create_table "users_events", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "users_events", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id"
     t.bigint "event_id"
     t.datetime "created_at", null: false

--- a/spec/controllers/books_controller_spec.rb
+++ b/spec/controllers/books_controller_spec.rb
@@ -31,8 +31,16 @@ RSpec.describe BooksController, type: :controller do
     FactoryBot.attributes_for :book
   end
 
+  let(:valid_attributes_with_courses_id_array) do
+    FactoryBot.attributes_for :book, courses: [ nil ]
+  end
+
   let(:invalid_attributes) do
     FactoryBot.attributes_for :book, price: :a_string
+  end
+
+  let(:invalid_attributes_with_courses_id_array) do
+    FactoryBot.attributes_for :book, price: :a_atring, courses: [ nil ]
   end
 
   # This should return the minimal set of values that should be in the session
@@ -64,12 +72,16 @@ RSpec.describe BooksController, type: :controller do
     context 'with valid params' do
       it 'creates a new Book' do
         expect do
-          post :create, params: { book: valid_attributes }, session: valid_session
+          post :create,
+            params: { book: valid_attributes_with_courses_id_array },
+            session: valid_session
         end.to change(Book, :count).by(1)
       end
 
       it 'renders a JSON response with the new book' do
-        post :create, params: { book: valid_attributes }, session: valid_session
+        post :create,
+          params: { book: valid_attributes_with_courses_id_array },
+          session: valid_session
         expect(response).to have_http_status(:created)
         expect(response.content_type).to eq('application/json')
         expect(response.location).to eq(book_url(Book.last))
@@ -78,7 +90,9 @@ RSpec.describe BooksController, type: :controller do
 
     context 'with invalid params' do
       it 'renders a JSON response with errors for the new book' do
-        post :create, params: { book: invalid_attributes }, session: valid_session
+        post :create,
+          params: { book: invalid_attributes_with_courses_id_array },
+          session: valid_session
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.content_type).to eq('application/json')
       end
@@ -105,7 +119,10 @@ RSpec.describe BooksController, type: :controller do
       it 'renders a JSON response with the book' do
         book = Book.create! valid_attributes
         book.update_attributes(user: current_user)
-        put :update, params: { id: book.to_param, book: valid_attributes }, session: valid_session
+        put :update,
+          params: { id: book.to_param,
+                    book: valid_attributes_with_courses_id_array },
+          session: valid_session
         expect(response).to have_http_status(:ok)
         expect(response.content_type).to eq('application/json')
       end
@@ -115,7 +132,10 @@ RSpec.describe BooksController, type: :controller do
       it 'renders a JSON response with errors for the book' do
         book = Book.create! valid_attributes
         book.update_attributes(user: current_user)
-        put :update, params: { id: book.to_param, book: invalid_attributes }, session: valid_session
+        put :update,
+          params: { id: book.to_param,
+                    book: invalid_attributes_with_courses_id_array },
+          session: valid_session
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.content_type).to eq('application/json')
       end

--- a/spec/factories/books.rb
+++ b/spec/factories/books.rb
@@ -15,5 +15,6 @@ FactoryBot.define do
     price { Faker::Number.between(0, 3000) }
     status { Faker::Number.between(0, 3) }
     view_count { 0 }
+    contact_way { Faker::Internet.email }
   end
 end


### PR DESCRIPTION
* 加入新欄位`contact_way`與其假資料，type為`string`
* 修改二手書的新增action，讓新增一筆二手書紀錄時可一併關連至`current_user`
* 加入`current_user`與二手書創建使用者是否相同的檢查及相關測試
* 調整二手書回傳json格式以符合前端要求